### PR TITLE
installで作成されるcmakeファイル名の変更

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories (
 
 install (
 	TARGETS "SeqMaker"
-	EXPORT SeqMaker-config
+	EXPORT seqmaker-config
   RUNTIME DESTINATION lib
 	ARCHIVE DESTINATION lib
 )
@@ -47,7 +47,7 @@ install (
 )
 
 install (
-	EXPORT SeqMaker-config
+	EXPORT seqmaker-config
 	NAMESPACE SeqMaker::
 	DESTINATION cmake
 )


### PR DESCRIPTION
CMakeの`find_package`コマンドは、

- `<PackageName>Config.cmake`
- `<lower-case-package-name>-config.cmake`

の命名規則に従うファイルを読み込む。

しかしながら、現在出力されるファイル名は`SeqMaker-config.cmake`であったため、`seqmaker-config.cmake`に変更し、`find_package`コマンドで検索されるようにした。


参考：https://cmake.org/cmake/help/v3.20/command/find_package.html