### PR TITLE
ヘッダのinclude名にSeqMaker/を追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ install (
 
 install (
 	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/shared/
-	DESTINATION include
+	DESTINATION include/SeqMaker/
 )
 
 install (


### PR DESCRIPTION
現在、install後の中身を外部から利用する際、

```c
#include <SeqMaker.h>
```

というような書き方をとる。

しかしながら、installによって生成されるincludeディレクトリ内には、typeディレクトリなど汎用性の高い名前が含まれており、無駄に名前被りの可能性が高くなってしまっている。

本変更により、

```c
#include <SeqMaker/SeqMaker.h>
```

のように、include名に`SeqMaker/`を必ず付加させるようにすることでこの問題を解決する。