### PR TITLE
名前の変更

### DIFF
--- a/include/NGram.hpp
+++ b/include/NGram.hpp
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 
-namespace NGram {
+namespace seq {
 
 template <typename T>
 class NGram {
@@ -52,4 +52,4 @@ class NGram {
   std::vector<std::vector<T>> ngram_;
 };
 
-}  // namespace NGram
+}  // namespace seq

--- a/include/NGram.hpp
+++ b/include/NGram.hpp
@@ -9,7 +9,7 @@ namespace NGram {
 
 template <typename T>
 class NGram {
-public:
+ public:
   NGram(const std::vector<T>& data, std::size_t n) : ngram_{} {
     if (data.size() < n) {
       throw std::runtime_error("入力データが短すぎます．");
@@ -30,8 +30,8 @@ public:
   NGram operator=(NGram&&) = delete;
   NGram operator=(const NGram&) = delete;
 
-  inline explicit operator std::string() const noexcept { return toString(); }
-  inline const std::string toString() const noexcept {
+  inline explicit operator std::string() const noexcept { return string(); }
+  inline const std::string string() const noexcept {
     std::string str{"{\n"};
     for (const auto& vec : ngram_) {
       str += '(';
@@ -47,7 +47,7 @@ public:
     return str;
   }
 
-private:
+ private:
   std::size_t n_;
   std::vector<std::vector<T>> ngram_;
 };

--- a/include/Protection.hpp
+++ b/include/Protection.hpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <stdexcept>
 
-namespace Protection {
+namespace seq::protect {
 
 using protect_t = std::uint8_t;
 
@@ -22,7 +22,7 @@ enum class Protections : protect_t {
 };
 
 class ProtectionMaster {
-public:
+ public:
   ProtectionMaster() = delete;
   ProtectionMaster(ProtectionMaster&&) = delete;
   ProtectionMaster(const ProtectionMaster&) = delete;
@@ -54,4 +54,4 @@ public:
   }
 };
 
-}  // namespace Protection
+}  // namespace seq::protect

--- a/include/Registers.hpp
+++ b/include/Registers.hpp
@@ -7,10 +7,10 @@
 #include <cstdint>
 #include <stdexcept>
 
-namespace Seq {
+namespace seq {
 
 class RegisterMaster {
-public:
+ public:
   RegisterMaster() = delete;
   RegisterMaster(RegisterMaster&&) = delete;
   RegisterMaster(const RegisterMaster&) = delete;
@@ -55,4 +55,4 @@ public:
   }
 };
 
-};  // namespace Seq
+};  // namespace seq

--- a/include/SeqMaker.hpp
+++ b/include/SeqMaker.hpp
@@ -17,10 +17,10 @@
 #include <utility>
 #include <vector>
 
-namespace Seq {
+namespace seq {
 
 class ISeqMaker {
-public:
+ public:
   virtual ~ISeqMaker() = 0;
   virtual void addInstruction(const Registers& regs) = 0;
   virtual char* createNGramString(std::size_t n) const = 0;
@@ -31,7 +31,7 @@ ISeqMaker::~ISeqMaker() {}
 template <class U>
   requires std::is_base_of_v<SeqUnit, U>
 class SeqMaker : public ISeqMaker {
-public:
+ public:
   inline SeqMaker(std::uint32_t pid) : hProcess_{}, seq_{} {
     hProcess_ = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
     // MSDN曰く、OpenProcess失敗時には「NULL」が返るとのことなので、
@@ -59,21 +59,20 @@ public:
     }
 
     ZydisDisassembledInstruction inst;
-    if (!ZYAN_SUCCESS(
-            ZydisDisassembleIntel(ZYDIS_MACHINE_MODE_LONG_COMPAT_32, static_cast<ZyanU64>(regs.EIP), buffer, sizeof(buffer), &inst))) {
+    if (!ZYAN_SUCCESS(ZydisDisassembleIntel(ZYDIS_MACHINE_MODE_LONG_COMPAT_32, static_cast<ZyanU64>(regs.EIP), buffer, sizeof(buffer), &inst))) {
       throw std::runtime_error("ディスアセンブルに失敗しました．");
     }
 
     seq_.emplace_back(hProcess_, regs, std::move(inst));
   }
 
-  inline const NGram::NGram<U> createNGram(size_t n) const { return NGram::NGram<U>{seq_, n}; }
-  inline char* createNGramString(std::size_t n) const override { return strdup(createNGram(n).toString().c_str()); }
+  inline const NGram<U> createNGram(size_t n) const { return NGram<U>{seq_, n}; }
+  inline char* createNGramString(std::size_t n) const override { return strdup(createNGram(n).string().c_str()); }
 
-private:
+ private:
   inline constexpr static std::size_t IA32_MAX_INST_LENGTH_ = 15;
   HANDLE hProcess_;
   std::vector<U> seq_;
 };
 
-}  // namespace Seq
+}  // namespace seq

--- a/include/SeqUnit.hpp
+++ b/include/SeqUnit.hpp
@@ -8,7 +8,7 @@
 #include <winnt.h>
 #include <string>
 
-namespace Seq {
+namespace seq {
 
 class SeqUnit {
  public:
@@ -16,4 +16,4 @@ class SeqUnit {
   virtual const std::string string() const noexcept = 0;
 };
 
-};  // namespace Seq
+};  // namespace seq

--- a/include/SeqUnit.hpp
+++ b/include/SeqUnit.hpp
@@ -11,9 +11,9 @@
 namespace Seq {
 
 class SeqUnit {
-public:
-  inline explicit virtual operator std::string() const noexcept { return toString(); }
-  virtual const std::string toString() const noexcept = 0;
+ public:
+  inline explicit virtual operator std::string() const noexcept { return string(); }
+  virtual const std::string string() const noexcept = 0;
 };
 
 };  // namespace Seq

--- a/include/SeqUnitMnemonic.hpp
+++ b/include/SeqUnitMnemonic.hpp
@@ -16,7 +16,7 @@ class SeqUnitMnemonic : public SeqUnit {
   SeqUnitMnemonic& operator=(SeqUnitMnemonic&&) = default;
   SeqUnitMnemonic& operator=(const SeqUnitMnemonic&) = default;
 
-  inline const std::string toString() const noexcept override {
+  inline const std::string string() const noexcept override {
     /*
     {
       mnemonic: ニーモニック

--- a/include/SeqUnitMnemonic.hpp
+++ b/include/SeqUnitMnemonic.hpp
@@ -4,7 +4,7 @@
 
 #include <format>
 
-namespace Seq {
+namespace seq {
 
 class SeqUnitMnemonic : public SeqUnit {
  public:
@@ -29,4 +29,4 @@ class SeqUnitMnemonic : public SeqUnit {
   std::string mnemonic_;
 };
 
-};  // namespace Seq
+};  // namespace seq

--- a/include/SeqUnitOpcode.hpp
+++ b/include/SeqUnitOpcode.hpp
@@ -4,7 +4,7 @@
 
 #include <format>
 
-namespace Seq {
+namespace seq {
 
 class SeqUnitOpcode : public SeqUnit {
  public:
@@ -29,4 +29,4 @@ class SeqUnitOpcode : public SeqUnit {
   ZyanU8 opcode_;
 };
 
-};  // namespace Seq
+};  // namespace seq

--- a/include/SeqUnitOpcode.hpp
+++ b/include/SeqUnitOpcode.hpp
@@ -16,7 +16,7 @@ class SeqUnitOpcode : public SeqUnit {
   SeqUnitOpcode& operator=(SeqUnitOpcode&&) = default;
   SeqUnitOpcode& operator=(const SeqUnitOpcode&) = default;
 
-  inline const std::string toString() const noexcept override {
+  inline const std::string string() const noexcept override {
     /*
     {
       opcode: オペコード

--- a/include/SeqUnitOriginal.hpp
+++ b/include/SeqUnitOriginal.hpp
@@ -26,7 +26,7 @@ class OperandInfo {
     MemoryAccessRWX,
   };
 
-  inline const std::string toString() const noexcept {
+  inline const std::string string() const noexcept {
     switch (val_) {
       case Values::NonMemoryAccess:
         return "NonMemoryAccess";
@@ -88,7 +88,7 @@ class SeqUnitOriginal : public SeqUnit {
   SeqUnitOriginal& operator=(SeqUnitOriginal&&) = default;
   SeqUnitOriginal& operator=(const SeqUnitOriginal&) = default;
 
-  inline const std::string toString() const noexcept override {
+  inline const std::string string() const noexcept override {
     /*
     {
       mnemonic: ニーモニック,
@@ -97,7 +97,7 @@ class SeqUnitOriginal : public SeqUnit {
       src2: None|NonMemoryAccess|MemoryAccess
     }
     */
-    return std::format("{{mnemonic: {}, dest: {}, src1: {}, src2: {}}}", mnemonic_, dest_->toString(), src1_->toString(), src2_->toString());
+    return std::format("{{mnemonic: {}, dest: {}, src1: {}, src2: {}}}", mnemonic_, dest_->string(), src1_->string(), src2_->string());
   }
 
  private:

--- a/include/SeqUnitOriginal.hpp
+++ b/include/SeqUnitOriginal.hpp
@@ -8,7 +8,7 @@
 #include <format>
 #include <optional>
 
-namespace Seq {
+namespace seq {
 
 class OperandInfo {
  public:
@@ -55,7 +55,7 @@ class OperandInfo {
   Values val_;
 
   static std::uint32_t calcMemoryAddress(const Registers& regs, const ZydisDecodedOperandMem& mem);
-  static Protection::Protections getMemoryProtection(HANDLE hProcess, std::uint32_t address);
+  static protect::Protections getMemoryProtection(HANDLE hProcess, std::uint32_t address);
 };
 
 class DestInfo : public OperandInfo {
@@ -111,4 +111,4 @@ class SeqUnitOriginal : public SeqUnit {
   inline bool isSrc2Operand(const ZydisDecodedOperand& op) const noexcept { return !src2_.has_value() && (op.actions & ZYDIS_OPERAND_ACTION_READ); }
 };
 
-};  // namespace Seq
+};  // namespace seq

--- a/src/DllMain.cpp
+++ b/src/DllMain.cpp
@@ -17,7 +17,7 @@ static void debug_print(const std::exception& e) {
 #endif
 
 using namespace std;
-using namespace Seq;
+using namespace seq;
 
 class SEQMAKER_ {
  public:

--- a/src/SeqUnitMnemonic.cpp
+++ b/src/SeqUnitMnemonic.cpp
@@ -1,6 +1,6 @@
 #include <SeqUnitMnemonic.hpp>
 
-using namespace Seq;
+using namespace seq;
 
 SeqUnitMnemonic::SeqUnitMnemonic(HANDLE, const Registers&, ZydisDisassembledInstruction&& inst) : mnemonic_{} {
   const char* mnemonic = ZydisMnemonicGetString(inst.info.mnemonic);

--- a/src/SeqUnitOpcode.cpp
+++ b/src/SeqUnitOpcode.cpp
@@ -1,5 +1,5 @@
 #include <SeqUnitOpcode.hpp>
 
-using namespace Seq;
+using namespace seq;
 
 SeqUnitOpcode::SeqUnitOpcode(HANDLE, const Registers&, ZydisDisassembledInstruction&& inst) : opcode_{inst.info.opcode} {}

--- a/src/SeqUnitOriginal.cpp
+++ b/src/SeqUnitOriginal.cpp
@@ -4,8 +4,8 @@
 #include <processthreadsapi.h>
 #include <windef.h>
 
-using namespace Protection;
-using namespace Seq;
+using namespace seq;
+using namespace seq::protect;
 
 OperandInfo::~OperandInfo() {}
 


### PR DESCRIPTION
- `toString`メソッドを`string`メソッドに統一
  - メソッド名をJavaスタイルからC++スタイルに
- namespaceを小文字に統一
  - C++標準ライブラリはすべて小文字であるため
- `namespace NGram`を`namespace seq`に変更
  - 元の`NGram`では`seq`に含まれないため
  - namespace `NGram`には`class NGram`しか含んでおらず、`namespace NGram`を残す必要性が薄いため
- `namespace Protect`を`namespace seq::protect`に変更
  - 元の`Protect`では`seq`に含まれないため