### PR TITLE
ノート機能の追加

### DIFF
--- a/include/SeqUnit.hpp
+++ b/include/SeqUnit.hpp
@@ -33,6 +33,9 @@ class SeqUnit {
   bool isInstructionOf(ZydisMnemonic mnemonic) const noexcept;
   std::uint32_t operand(std::size_t no) const;
 
+  bool setNote(const char* note) noexcept;
+  const std::string note() const noexcept { return note_; }
+
  protected:
   const ZydisMnemonic mnemonic_;
   std::vector<IOperandInfo*> operands_;
@@ -40,7 +43,8 @@ class SeqUnit {
   std::vector<SrcInfo> allSrcOps_;
 
  private:
-  std::string str_;
+  std::string str_{};
+  std::string note_{};
 
   // Factoryを介さずにSeqUnitクラス群を作成してほしくないので
   // Factoryをfriendクラスにしつつ、子クラスのコンストラクタをprivateに記述

--- a/shared/SeqMaker.h
+++ b/shared/SeqMaker.h
@@ -21,6 +21,7 @@ SEQ_MAKER_EXPORT void SeqMaker_DeInit(SEQMAKER seq);
 
 SEQ_MAKER_EXPORT SEQ_UNITDATA SeqMaker_AddInstruction(SEQMAKER seq, const Registers* regs);
 SEQ_MAKER_EXPORT bool SeqMaker_GetUnitDataInfo(SEQ_UNITDATA unit, SEQ_UNITINFO_CONSTS info, void* output);
+SEQ_MAKER_EXPORT bool SeqMaker_AddNote(SEQ_UNITDATA unit, const char* note);
 
 SEQ_MAKER_EXPORT char* SeqMaker_CreateNGram(SEQMAKER seq, size_t n);
 

--- a/src/DllMain.cpp
+++ b/src/DllMain.cpp
@@ -125,6 +125,15 @@ SEQ_MAKER_EXPORT bool SeqMaker_GetUnitDataInfo(SEQ_UNITDATA unit, SEQ_UNITINFO_C
   }
 }
 
+SEQ_MAKER_EXPORT bool SeqMaker_AddNote(SEQ_UNITDATA unit, const char* note) {
+  if (unit == nullptr) {
+    return true;
+  }
+
+  auto u = const_cast<SeqUnit*>(static_cast<const SeqUnit*>(unit));
+  return u->setNote(note);
+}
+
 SEQ_MAKER_EXPORT char* SeqMaker_CreateNGram(SEQMAKER seq, std::size_t n) {
   if (seq == nullptr) {
     return nullptr;

--- a/src/SeqUnit.cpp
+++ b/src/SeqUnit.cpp
@@ -48,3 +48,12 @@ std::uint32_t SeqUnit::operand(std::size_t no) const {
     throw;
   }
 }
+
+bool SeqUnit::setNote(const char* note) noexcept {
+  try {
+    note_.assign(note);
+    return false;
+  } catch (...) {
+    return true;
+  }
+}

--- a/src/SeqUnitMnemonic.cpp
+++ b/src/SeqUnitMnemonic.cpp
@@ -11,7 +11,7 @@ SeqUnitMnemonic::SeqUnitMnemonic(HANDLE hProcess, const Registers& regs, const Z
     : SeqUnit{hProcess, regs, inst}, mnemonic_{instructionToMnemonic(inst)} {}
 
 std::string SeqUnitMnemonic::makeString() noexcept {
-  return std::format("{{mnemonic: {}}}", mnemonic_);
+  return std::format("{{mnemonic: {}, note: {}}}", mnemonic_, note());
 }
 
 static const char* instructionToMnemonic(const ZydisDisassembledInstruction& inst) {

--- a/src/SeqUnitOpcode.cpp
+++ b/src/SeqUnitOpcode.cpp
@@ -8,5 +8,5 @@ SeqUnitOpcode::SeqUnitOpcode(HANDLE hProcess, const Registers& regs, const Zydis
     : SeqUnit{hProcess, regs, inst}, opcode_{inst.info.opcode} {}
 
 std::string SeqUnitOpcode::makeString() noexcept {
-  return std::format("{{opcode: {:02X}}}", opcode_);
+  return std::format("{{opcode: {:02X}, note: {}}}", opcode_, note());
 }

--- a/src/SeqUnitOriginal.cpp
+++ b/src/SeqUnitOriginal.cpp
@@ -24,8 +24,8 @@ SeqUnitOriginal::SeqUnitOriginal(HANDLE hProcess, const Registers& regs, const Z
 }
 
 std::string SeqUnitOriginal::makeString() noexcept {
-  return std::format("{{mnemonic: {}, dest: {}, src1: {}, src2: {}}}", mnemonic_, dest_.protection().string(), src1_.protection().string(),
-                     src2_.protection().string());
+  return std::format("{{mnemonic: {}, dest: {}, src1: {}, src2: {}, note: {}}}", mnemonic_, dest_.protection().string(), src1_.protection().string(),
+                     src2_.protection().string(), note());
 }
 
 static const char* instructionToMnemonic(const ZydisDisassembledInstruction& inst) {


### PR DESCRIPTION
インタフェースに

```c
bool SeqMaker_AddNote(SEQ_UNITDATA unit, const char* note);
```

を追加し、呼び出し側が任意の項目を追加するための要素として、noteを設定できるように変更した。