### PR TITLE
コンソール出力の文字化けを対策

### DIFF
--- a/src/DllMain.cpp
+++ b/src/DllMain.cpp
@@ -5,6 +5,8 @@
 #include "SeqUnitOpcode.hpp"
 #include "SeqUnitOriginal.hpp"
 
+#include <stringapiset.h>
+
 #include <cstdint>
 #include <stdexcept>
 
@@ -13,7 +15,14 @@
 #else
 #include <iostream>
 static void debug_print(const std::exception& e) {
-  std::cerr << e.what() << std::endl;
+  auto mbslen = strlen(e.what());
+  auto wcslen = MultiByteToWideChar(CP_UTF8, 0, e.what(), mbslen, nullptr, 0);
+
+  std::wstring wcs(wcslen, L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, e.what(), mbslen, wcs.data(), wcs.length());
+
+  WriteConsoleW(GetStdHandle(STD_ERROR_HANDLE), wcs.data(), wcs.length(), nullptr, nullptr);
+  std::cerr << std::endl;
 }
 #endif
 


### PR DESCRIPTION
- fix #26 

---

従来の`std::cerr`を用いた出力では、UTF-8文字列の出力時に文字化けが生じる問題があった。

そこで、WinAPIの`MultiByteToWideChar`関数を用いたUTF-8からUTF-16への変換および、`WriteConsoleW`関数を用いたコンソールへの書き込み処理に変更することで対処した。