### PR TITLE
Unitのnote変更時にstr表現も設定しなおすように

### DIFF
--- a/src/SeqUnit.cpp
+++ b/src/SeqUnit.cpp
@@ -30,6 +30,7 @@ const SrcInfo SeqUnit::source(std::size_t no) const {
 bool SeqUnit::setNote(const char* note) noexcept {
   try {
     note_.assign(note);
+    str_.assign(makeString());
     return false;
   } catch (...) {
     return true;


### PR DESCRIPTION
- fix #27 

---

SeqUnitのnote変更の際に、string表現も設定しなおすことでnoteの変更を出力に反映するよう修正した。